### PR TITLE
Add bindings for jumping to the start and end

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,8 @@ members = [
 ]
 
 [features]
+default = ["emacs"]
+emacs = []
 
 [package.metadata.nix]
 build = true

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Inspired by `rustyline` , `async-readline` & `termion-async-input`. Built using 
  * Ctrl-C, Ctrl-D are returned as `Err(Interrupt)` and `Err(Eof)` respectively.
  * Ctrl-U to clear line before cursor
  * Ctrl-left & right to move to next or previous whitespace
+ * Home/Ctrl-A and End/Ctrl-E to jump to the start and end of the input
  * Ctrl-L clear screen
  * Extensible design based on `crossterm`'s `event-stream` feature
 

--- a/examples/readline/Cargo.toml
+++ b/examples/readline/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rustyline-async = { path = "../.." }
+rustyline-async = { path = "../..", default-features = false }
 async-std = { version = "1.11.0", features = [ "unstable", "attributes" ] }
 futures = "0.3.21"
 log = "0.4.16"
@@ -14,4 +14,4 @@ pin-project = "1.0.10"
 simplelog = "0.11.2"
 
 [features]
-
+emacs = ["rustyline-async/emacs"]

--- a/examples/test-printing/Cargo.toml
+++ b/examples/test-printing/Cargo.toml
@@ -8,7 +8,8 @@ edition = "2021"
 [dependencies]
 async-std = { version = "1.11.0", features = ["attributes"] }
 log = "0.4.16"
-rustyline-async = { version = "0.2.0", path = "../.." }
+rustyline-async = { version = "0.2.0", path = "../..", default-features = false }
 simplelog = "0.11.2"
 
 [features]
+emacs = ["rustyline-async/emacs"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -215,6 +215,16 @@ impl LineState {
 					self.move_cursor(1)?;
 					self.set_cursor(term)?;
 				}
+				KeyCode::Home => {
+					self.reset_cursor(term)?;
+					self.move_cursor(-100000)?;
+					self.set_cursor(term)?;
+				}
+				KeyCode::End => {
+					self.reset_cursor(term)?;
+					self.move_cursor(100000)?;
+					self.set_cursor(term)?;
+				}
 				// Add character to line and output
 				KeyCode::Char(c) => {
 					self.clear(term)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -273,6 +273,16 @@ impl LineState {
 						self.clear_and_render(term)?;
 					}
 				}
+				KeyCode::Char('a') => {
+					self.reset_cursor(term)?;
+					self.move_cursor(-100000)?;
+					self.set_cursor(term)?;
+				}
+				KeyCode::Char('e') => {
+					self.reset_cursor(term)?;
+					self.move_cursor(100000)?;
+					self.set_cursor(term)?;
+				}
 				// Move cursor left to previous word
 				KeyCode::Left => {
 					self.reset_cursor(term)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -283,11 +283,13 @@ impl LineState {
 						self.clear_and_render(term)?;
 					}
 				}
+				#[cfg(feature="emacs")]
 				KeyCode::Char('a') => {
 					self.reset_cursor(term)?;
 					self.move_cursor(-100000)?;
 					self.set_cursor(term)?;
 				}
+				#[cfg(feature="emacs")]
 				KeyCode::Char('e') => {
 					self.reset_cursor(term)?;
 					self.move_cursor(100000)?;


### PR DESCRIPTION
This implements functionality when pressing `Home` or `End` keys to go the beginning and end of the input respectively.

This also adds `Ctrl-A` and `Ctrl-E` as the well-known Emacs-based aliases for these actions.