### PR TITLE
Implement a history

### DIFF
--- a/examples/readline/src/main.rs
+++ b/examples/readline/src/main.rs
@@ -10,7 +10,7 @@ async fn main() -> Result<(), ReadlineError> {
 	let mut periodic_timer1 = stream::interval(Duration::from_secs(2));
 	let mut periodic_timer2 = stream::interval(Duration::from_secs(3));
 
-	let (mut rl, mut stdout) = Readline::new("> ".to_owned()).unwrap();
+	let (mut rl, mut stdout) = Readline::with_history("> ".to_owned(), 5).unwrap();
 
 	simplelog::WriteLogger::init(
 		log::LevelFilter::Debug,

--- a/examples/readline/src/main.rs
+++ b/examples/readline/src/main.rs
@@ -32,7 +32,9 @@ async fn main() -> Result<(), ReadlineError> {
 			}
 			command = rl.readline().fuse() => match command {
 				Ok(line) => {
-					match line.trim() {
+					let line = line.trim();
+					rl.add_history_entry(line.to_owned());
+					match line {
 						"start task" => {
 							writeln!(stdout, "Starting the task...")?;
 							running_first = true;

--- a/examples/readline/src/main.rs
+++ b/examples/readline/src/main.rs
@@ -33,7 +33,7 @@ async fn main() -> Result<(), ReadlineError> {
 			command = rl.readline().fuse() => match command {
 				Ok(line) => {
 					let line = line.trim();
-					rl.add_history_entry(line.to_owned());
+					rl.add_history_entry(line.to_owned()).await;
 					match line {
 						"start task" => {
 							writeln!(stdout, "Starting the task...")?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -491,8 +491,7 @@ impl io::Write for SharedWriter {
 /// Structure that contains all the data necessary to read and write lines in an asyncronous manner
 pub struct Readline {
 	raw_term: Stdout,
-	event_stream: EventStream,
-	// Stream of events
+	event_stream: EventStream, // Stream of events
 	line_receiver: Receiver<Vec<u8>>,
 
 	line: LineState, // Current line


### PR DESCRIPTION
This implements a simple optional history, that can be manually appended to through a function on `Readline`.

History entries can be recalled by using the arrow keys.
I chose to make the history unchangeable, although there are shells that allow the user to change history entries.

## Usage

A `Readline` with history can be created using `Readline::with_history(prompt, max_size)`.
New history entries can be appended using `Readline::add_history_entry(entry)`.

## Up for debate

- Should the history really be unchangeable?
- Should this be hidden behind a feature flag?
- The implementation currently uses a `Mutex` to ensure thread-safety of appending new entries.
   Alternatives:
     - Use a `RwLock` instead, currently not really useful as there aren't really any read-only accesses.
     - Remove the thread-safety and let the user handle mutable concurrent accesses to `Readline`
- Should there be a way to get (read-only) access to the history from `Readline`?
- Should this be separated into its own file? (Should be a general consideration in this library :) )
- Should the constructor be changed into accepting struct/builder for the history size (and future additional parameters)?
- The `VecDeque` used is currently created through default.
   Technically a capacity could be specified based on the `max_size`.
   This could consume unnecessarily large memory amounts when the `max_size` is high, but the history's actual length is low.