### PR TITLE
Fix double key presses on Windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 edition = "2021"
 
 [dependencies]
-crossterm = { version = "0.26", features = ["event-stream"] }
+crossterm = { version = "0.25.0", features = ["event-stream"] }
 futures = "0.3"
 pin-project = "1.0"
 thingbuf = "0.1"


### PR DESCRIPTION
This is a simple fix for the [double key presses on Windows issue](https://github.com/zyansheep/rustyline-async/issues/12).
Just downgraded crossterm from 0.26 to 0.25.0, the [changes](https://github.com/crossterm-rs/crossterm/blob/master/CHANGELOG.md#version-0260) from one version to another are minimal and the crate uses none of them.
I also tried the latest version of crossterm, but it still broken.