### PR TITLE
Flush even when returning an error

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -188,7 +188,10 @@ impl Readline {
 					Some(Ok(event)) => {
 						match self.line.handle_event(event, &mut self.raw_term).await {
 							Ok(Some(line)) => return Result::<_, ReadlineError>::Ok(line),
-							Err(e) => return Err(e),
+							Err(e) => {
+								self.raw_term.flush()?;
+								return Err(e)
+							},
 							Ok(None) => self.raw_term.flush()?,
 						}
 					}


### PR DESCRIPTION
This fixes a dirty input line after pressing Ctrl+C when `rl.should_print_line_on(false, false)` is set and nothing else is printed afterwards.

The readline example can be modified to show this by uncommenting the `rl.should_print_line_on(false, false)` line and removing the `writeln!` from the `Err(ReadlineError::Interrupted)` branch.