### PR TITLE
Use `#[error(transparent)]` for `ReadlineError::IO`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@ use line::LineState;
 /// Error returned from `readline()`. These generally require specific processes to recover from.
 #[derive(Debug, Error)]
 pub enum ReadlineError {
-	#[error("io: {0}")]
+	#[error(transparent)]
 	IO(#[from] io::Error),
 	#[error("line writers closed")]
 	Closed,


### PR DESCRIPTION
thiserror's `error(transparent)` attribute causes the `Display` and `source()` of the annotated error variant to forward directly to the inner error.  In contrast, the current `Display` for I/O errors adds basically nothing to the inner `io::Error`'s `Display`, and if a `ReadlineError` were to be wrapped in a type like `anyhow::Error` that displays the full error chain on exit, the I/O error message would be output twice, e.g.:

    Error: io: input pipe broke

    Caused by:
        input pipe broke

By using `error(transparent)` instead, the output changes to just:

    Error: input pipe broke