### PR TITLE
Only respond to key presses; update crossterm to 0.27.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,6 +182,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitflags"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
+
+[[package]]
 name = "blocking"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -243,11 +249,11 @@ dependencies = [
 
 [[package]]
 name = "crossterm"
-version = "0.25.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e64e6c0fbe2c17357405f7c758c1ef960fce08bdfb2c03d88d2a18d7e09c4b67"
+checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
 dependencies = [
- "bitflags",
+ "bitflags 2.4.1",
  "crossterm_winapi",
  "futures-core",
  "libc",
@@ -641,7 +647,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b2d323e8ca7996b3e23126511a523f7e62924d93ecd5ae73b333815b0eb3dce"
 dependencies = [
  "autocfg",
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if",
  "concurrent-queue",
  "libc",
@@ -674,7 +680,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -689,7 +695,7 @@ version = "0.37.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d69718bf81c6127a49dc64e44a742e8bb9213c0ff8869a22c308f84c1d4ab06"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "errno",
  "io-lifetimes",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 edition = "2021"
 
 [dependencies]
-crossterm = { version = "0.25.0", features = ["event-stream"] }
+crossterm = { version = "0.27.0", features = ["event-stream"] }
 futures = "0.3"
 pin-project = "1.0"
 thingbuf = "0.1"
@@ -19,7 +19,7 @@ unicode-width = "0.1"
 
 [dev-dependencies]
 async-std = { version = "1.12.0", features = [ "unstable", "attributes" ] }
-tokio = { version = "1", features = ["full"] } 
+tokio = { version = "1", features = ["full"] }
 log = "0.4.17"
 simplelog = "0.12.0"
 

--- a/src/line.rs
+++ b/src/line.rs
@@ -2,7 +2,7 @@ use std::io::{self, Write};
 
 use crossterm::{
 	cursor,
-	event::{Event, KeyCode, KeyEvent, KeyModifiers},
+	event::{Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers},
 	terminal::{Clear, ClearType::*},
 	QueueableCommand,
 };
@@ -185,6 +185,7 @@ impl LineState {
 			Event::Key(KeyEvent {
 				code,
 				modifiers: KeyModifiers::CONTROL,
+				kind: KeyEventKind::Press,
 				..
 			}) => match code {
 				// End of transmission (CTRL-D)
@@ -302,7 +303,10 @@ impl LineState {
 			// combined KeyModifiers. Control+Alt is used to reach certain special symbols on a lot
 			// of international keyboard layouts.
 			Event::Key(KeyEvent {
-				code, modifiers: _, ..
+				code,
+				modifiers: _,
+				kind: KeyEventKind::Press,
+				..
 			}) => match code {
 				KeyCode::Enter => {
 					// Print line so you can see what commands you've typed


### PR DESCRIPTION
I believe this is the correct fix for #12.