### PR TITLE
Feature/adjustable prompt

### DIFF
--- a/src/history.rs
+++ b/src/history.rs
@@ -1,6 +1,7 @@
 use std::collections::VecDeque;
 
 use futures_channel::mpsc::{self, UnboundedReceiver, UnboundedSender};
+use futures_util::StreamExt;
 
 pub struct History {
 	pub entries: VecDeque<String>,
@@ -27,7 +28,7 @@ impl History {
 	// Update history entries
 	pub async fn update(&mut self) {
 		// Receive all new lines
-		while let Ok(Some(line)) = self.receiver.try_next() {
+		while let Some(line) = self.receiver.next().await {
 			// Don't add entry if last entry was same, or line was empty.
 			if self.entries.front() == Some(&line) || line.is_empty() {
 				continue;

--- a/src/history.rs
+++ b/src/history.rs
@@ -27,11 +27,11 @@ impl Default for History {
 impl History {
 	// Update history entries
 	pub async fn update(&mut self) {
-		// Receive all new lines
-		while let Some(line) = self.receiver.next().await {
+		// Receive a new line
+		if let Some(line) = self.receiver.next().await {
 			// Don't add entry if last entry was same, or line was empty.
 			if self.entries.front() == Some(&line) || line.is_empty() {
-				continue;
+				return;
 			}
 			// Add entry to front of history
 			self.entries.push_front(line);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -278,7 +278,7 @@ impl Readline {
 			select! {
 				event = self.event_stream.next().fuse() => match event {
 					Some(Ok(event)) => {
-						match self.line.handle_event(event, &mut self.raw_term).await {
+						match self.line.handle_event(event, &mut self.raw_term) {
 							Ok(Some(event)) => {
 								self.raw_term.flush()?;
 								return Result::<_, ReadlineError>::Ok(event)
@@ -296,7 +296,8 @@ impl Readline {
 						self.raw_term.flush()?;
 					},
 					None => return Err(ReadlineError::Closed),
-				}
+				},
+				_ = self.line.history.update().fuse() => {}
 			}
 		}
 	}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -224,10 +224,9 @@ impl Readline {
 		))
 	}
 
-	/// Change the prompt starting on next readline
-	pub fn set_prompt(&mut self, prompt: String) -> Result<(), ReadlineError> {
-		self.line.prompt = prompt;
-		self.line.clear_and_render(&mut self.raw_term)?;
+	/// Change the prompt
+	pub fn update_prompt(&mut self, prompt: String) -> Result<(), ReadlineError> {
+		self.line.update_prompt(prompt, &mut self.raw_term)?;
 		Ok(())
 	}
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -224,6 +224,13 @@ impl Readline {
 		))
 	}
 
+	/// Change the prompt starting on next readline
+	pub fn set_prompt(&mut self, prompt: String) -> Result<(), ReadlineError> {
+		self.line.prompt = prompt;
+		self.line.clear_and_render(&mut self.raw_term)?;
+		Ok(())
+	}
+
 	/// Clear the screen
 	pub fn clear(&mut self) -> Result<(), ReadlineError> {
 		self.raw_term.queue(Clear(terminal::ClearType::All))?;

--- a/src/line.rs
+++ b/src/line.rs
@@ -178,14 +178,11 @@ impl LineState {
 		term.flush()?;
 		Ok(())
 	}
-	pub async fn handle_event(
+	pub fn handle_event(
 		&mut self,
 		event: Event,
 		term: &mut impl Write,
 	) -> Result<Option<ReadlineEvent>, ReadlineError> {
-		// Update history entries
-		self.history.update().await;
-
 		match event {
 			// Control Keys
 			Event::Key(KeyEvent {

--- a/src/line.rs
+++ b/src/line.rs
@@ -23,7 +23,7 @@ pub struct LineState {
 
 	cluster_buffer: String, // buffer for holding partial grapheme clusters as they come in
 
-	prompt: String,
+	pub(crate) prompt: String,
 	pub should_print_line_on_enter: bool, // After pressing enter, should we print the line just submitted?
 	pub should_print_line_on_control_c: bool, // After pressing control_c should we print the line just cancelled?
 

--- a/src/line.rs
+++ b/src/line.rs
@@ -1,10 +1,7 @@
 use std::io::{self, Write};
 
 use crossterm::{
-	cursor,
-	event::{Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers},
-	terminal::{Clear, ClearType::*},
-	QueueableCommand,
+	cursor, event::{Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers}, terminal::{Clear, ClearType::*}, ExecutableCommand, QueueableCommand
 };
 
 use unicode_segmentation::UnicodeSegmentation;
@@ -23,7 +20,7 @@ pub struct LineState {
 
 	cluster_buffer: String, // buffer for holding partial grapheme clusters as they come in
 
-	pub(crate) prompt: String,
+	prompt: String,
 	pub should_print_line_on_enter: bool, // After pressing enter, should we print the line just submitted?
 	pub should_print_line_on_control_c: bool, // After pressing control_c should we print the line just cancelled?
 
@@ -170,6 +167,15 @@ impl LineState {
 	}
 	pub fn print(&mut self, string: &str, term: &mut impl Write) -> Result<(), ReadlineError> {
 		self.print_data(string.as_bytes(), term)?;
+		Ok(())
+	}
+	pub fn update_prompt(&mut self, prompt: String, term: &mut impl Write) -> Result<(), ReadlineError> {
+		self.clear(term)?;
+		self.prompt = prompt;
+		// recalculates column
+		self.move_cursor(0)?;
+		self.render(term)?;
+		term.flush()?;
 		Ok(())
 	}
 	pub async fn handle_event(


### PR DESCRIPTION
Ability to update the prompt string after readline creation, updates cursor positions and applies immediately so you can do neat things like show a spinner in the prompt.

Couldn't figure out if there was a better/async way to handle getting the updates to apply immediately, if I don't flush the crossterm instance it doesn't apply until some key is pressed which looks janky. I'm assuming a flush doesn't meaningfully block since there are other places it appeared already.

I tested the changes in a project I'm working on using the prompt, works great for my use case of showing a status message. Not sure if there's extra documentation or testing required.