### PR TITLE
Feature/programmatic clear

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,7 @@ use std::{
 
 use crossterm::{
 	event::EventStream,
-	terminal::{self, disable_raw_mode},
+	terminal::{self, disable_raw_mode, Clear},
 	QueueableCommand,
 };
 use futures_channel::mpsc;
@@ -222,6 +222,12 @@ impl Readline {
 				buffer: Vec::new(),
 			},
 		))
+	}
+
+	pub fn clear(&mut self) -> Result<(), ReadlineError> {
+		self.raw_term.queue(Clear(terminal::ClearType::All))?;
+		self.line.clear_and_render(&mut self.raw_term)?;
+		Ok(())
 	}
 
 	/// Set maximum history length.  The default length is 1000.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -224,9 +224,11 @@ impl Readline {
 		))
 	}
 
+	/// Clear the screen
 	pub fn clear(&mut self) -> Result<(), ReadlineError> {
 		self.raw_term.queue(Clear(terminal::ClearType::All))?;
 		self.line.clear_and_render(&mut self.raw_term)?;
+		self.raw_term.flush()?;
 		Ok(())
 	}
 


### PR DESCRIPTION
Add a clear method to readline, does the same thing as Ctrl+L, but able to be called programmatically without importing all of crossterm to send an event. 

Useful to add a named "clear" command to a shell that's attempting to be "user friendly"