### PR TITLE
Fix: ensure reset of history position after line entry

### DIFF
--- a/src/history.rs
+++ b/src/history.rs
@@ -31,12 +31,10 @@ impl History {
 		if let Some(line) = self.receiver.next().await {
 			// Reset offset to newest entry
 			self.current_position = None;
-
 			// Don't add entry if last entry was same, or line was empty.
 			if self.entries.front() == Some(&line) || line.is_empty() {
 				return;
 			}
-
 			// Add entry to front of history
 			self.entries.push_front(line);
 			// Check if already have enough entries
@@ -45,6 +43,11 @@ impl History {
 				self.entries.pop_back();
 			}
 		}
+	}
+
+	// Sets the history position back to the start.
+	pub fn reset_position(&mut self) {
+		self.current_position = None;
 	}
 
 	// Find next history that matches a given string from an index

--- a/src/history.rs
+++ b/src/history.rs
@@ -29,14 +29,16 @@ impl History {
 	pub async fn update(&mut self) {
 		// Receive a new line
 		if let Some(line) = self.receiver.next().await {
+			// Reset offset to newest entry
+			self.current_position = None;
+
 			// Don't add entry if last entry was same, or line was empty.
 			if self.entries.front() == Some(&line) || line.is_empty() {
 				return;
 			}
+
 			// Add entry to front of history
 			self.entries.push_front(line);
-			// Reset offset to newest entry
-			self.current_position = None;
 			// Check if already have enough entries
 			if self.entries.len() > self.max_size {
 				// Remove oldest entry

--- a/src/line.rs
+++ b/src/line.rs
@@ -324,6 +324,7 @@ impl LineState {
 					// Render new line from beginning
 					self.move_cursor(-100000)?;
 					self.clear_and_render(term)?;
+					self.history.reset_position();
 
 					// Return line
 					return Ok(Some(ReadlineEvent::Line(line)));


### PR DESCRIPTION
The library seems to have an issue with the history (or at least some unexpected behavior for me), if I keep repeating the last command. Here is a quick example to reproduce this:

```rust
#[tokio::main]
async fn main() {
	let (mut rl, mut writer) = Readline::new("prompt> ".into()).unwrap();

	loop {
		match rl.readline().await.unwrap() {
			ReadlineEvent::Line(line) => {
				if !line.is_empty() {
					rl.add_history_entry(line.clone());
					writeln!(writer, "{line}").unwrap();
				}
			},
			_ => break,
		}
	}
}
```

This is what happens:

```
prompt> foo[ENTER]
foo
prompt> bar[ENTER]
bar
prompt> [UP][ENTER]
bar
prompt> [UP][ENTER]
foo
prompt> [UP][ENTER]
foo
prompt> [UP][ENTER]
bar
prompt> [UP][ENTER]
bar
prompt> [UP][ENTER]
foo
...
```

I would expect Up + Enter to always repeat "bar" and not bring up "foo" at all. The issue seems to be that when the history detects the same entry as last time (which is the case after the first Up + Enter), it will *not* reset the history position. Therefore the second Up + Enter will produce "foo" instead of "bar".

This pull request includes two changes:

a) It will always reset the history position when an entry is added to the history. Previously, this was only the case when the entry is different from the last one.

b) I've added code that will reset the history position on "Enter", even when nothing is added to the history. I'd argue, that after entering a line, the state should be reset, so that navigating the history on the next input prompt starts from a clean state. I think this makes more sense, but I could also update the pull request to include a configuration option for this.