### PR TITLE
History export / import to file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -691,7 +691,6 @@ version = "0.4.3"
 dependencies = [
  "async-std",
  "crossterm",
- "futures-channel",
  "futures-util",
  "log",
  "pin-project",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ edition = "2021"
 
 [dependencies]
 crossterm = { version = "0.28.1", features = ["event-stream"] }
-futures-channel = "0.3"
 futures-util = { version = "0.3", features = ["io"] }
 pin-project = "1.0"
 thingbuf = "0.1"

--- a/src/history.rs
+++ b/src/history.rs
@@ -1,6 +1,7 @@
 use std::collections::VecDeque;
 
 pub struct History {
+	// Note: old entries in front, new ones at the back.
 	pub entries: VecDeque<String>,
 	pub max_size: usize,
 	current_position: Option<usize>,
@@ -21,15 +22,15 @@ impl History {
 		// Reset offset to newest entry
 		self.current_position = None;
 		// Don't add entry if last entry was same, or line was empty.
-		if self.entries.front() == Some(&line) || line.is_empty() {
+		if self.entries.back() == Some(&line) || line.is_empty() {
 			return;
 		}
-		// Add entry to front of history
-		self.entries.push_front(line);
+		// Add entry to back of history
+		self.entries.push_back(line);
 		// Check if already have enough entries
 		if self.entries.len() > self.max_size {
 			// Remove oldest entry
-			self.entries.pop_back();
+			self.entries.pop_front();
 		}
 	}
 
@@ -41,25 +42,26 @@ impl History {
 	// Find next history that matches a given string from an index
 	pub fn search_next(&mut self, _current: &str) -> Option<&str> {
 		if let Some(index) = &mut self.current_position {
-			if *index < self.entries.len() - 1 {
-				*index += 1;
+			if *index > 0 {
+				*index -= 1;
 			}
 			Some(&self.entries[*index])
-		} else if !self.entries.is_empty() {
-			self.current_position = Some(0);
-			Some(&self.entries[0])
+		} else if let Some(last) = self.entries.back() {
+			self.current_position = Some(self.entries.len() - 1);
+			Some(last)
 		} else {
 			None
 		}
 	}
+
 	// Find previous history item that matches a given string from an index
 	pub fn search_previous(&mut self, _current: &str) -> Option<&str> {
 		if let Some(index) = &mut self.current_position {
-			if *index == 0 {
+			if *index == self.entries.len() - 1 {
 				self.current_position = None;
 				return Some("");
 			}
-			*index -= 1;
+			*index += 1;
 			Some(&self.entries[*index])
 		} else {
 			None

--- a/src/history.rs
+++ b/src/history.rs
@@ -2,8 +2,8 @@ use std::collections::VecDeque;
 
 pub struct History {
 	// Note: old entries in front, new ones at the back.
-	pub entries: VecDeque<String>,
-	pub max_size: usize,
+	entries: VecDeque<String>,
+	max_size: usize,
 	current_position: Option<usize>,
 }
 impl Default for History {
@@ -32,6 +32,36 @@ impl History {
 			// Remove oldest entry
 			self.entries.pop_front();
 		}
+	}
+
+	// Changes the history size.
+	pub fn set_max_size(&mut self, max_size: usize) {
+		self.max_size = max_size;
+
+		while self.entries.len() > max_size {
+			// Remove oldest entry
+			self.entries.pop_front();
+		}
+
+		// Make sure we don't end up in an invalid position.
+		self.reset_position();
+	}
+
+	// Returns the current history entries.
+	pub fn get_entries(&self) -> &VecDeque<String> {
+		&self.entries
+	}
+
+	// Replaces the current history entries.
+	pub fn set_entries(&mut self, entries: impl IntoIterator<Item = String>) {
+		self.entries.clear();
+
+		// Using `add_entry` will respect `max_size` and remove duplicate lines etc.
+		for entry in entries.into_iter() {
+			self.add_entry(entry);
+		}
+
+		self.reset_position();
 	}
 
 	// Sets the history position back to the start.
@@ -70,8 +100,8 @@ impl History {
 }
 
 #[cfg(test)]
-#[tokio::test]
-async fn test_history() {
+#[test]
+fn test_history() {
 	let mut history = History::default();
 
 	history.add_entry("foo".into());
@@ -112,8 +142,8 @@ async fn test_history() {
 }
 
 #[cfg(test)]
-#[tokio::test]
-async fn test_history_limit() {
+#[test]
+fn test_history_limit() {
 	let mut history = History {
 		max_size: 3,
 		..Default::default()
@@ -128,4 +158,60 @@ async fn test_history_limit() {
 	assert_eq!(Some("baz"), history.search_next(""));
 	assert_eq!(Some("bar"), history.search_next(""));
 	assert_eq!(Some("bar"), history.search_next(""));
+
+	history.set_max_size(2);
+
+	assert_eq!(Some("qux"), history.search_next(""));
+	assert_eq!(Some("baz"), history.search_next(""));
+	assert_eq!(Some("baz"), history.search_next(""));
+}
+
+#[cfg(test)]
+#[test]
+fn test_history_reset_on_add() {
+	let mut history = History::default();
+
+	history.add_entry("foo".into());
+	history.add_entry("bar".into());
+	history.add_entry("baz".into());
+
+	assert_eq!(None, history.search_previous(""));
+	assert_eq!(Some("baz"), history.search_next(""));
+	assert_eq!(Some("bar"), history.search_next(""));
+
+	// This should reset the history position.
+	history.add_entry("qux".into());
+
+	assert_eq!(None, history.search_previous(""));
+	assert_eq!(Some("qux"), history.search_next(""));
+	assert_eq!(Some("baz"), history.search_next(""));
+	assert_eq!(Some("bar"), history.search_next(""));
+	assert_eq!(Some("foo"), history.search_next(""));
+}
+
+#[cfg(test)]
+#[test]
+fn test_history_export() {
+	let mut history = History {
+		max_size: 3,
+		..Default::default()
+	};
+
+	assert_eq!(history.get_entries(), &VecDeque::new());
+
+	history.add_entry("foo".into());
+	history.add_entry("bar".into());
+	history.add_entry("baz".into());
+
+	assert_eq!(history.get_entries(), &["foo", "bar", "baz"]);
+
+	history.add_entry("qux".into());
+
+	assert_eq!(history.get_entries(), &["bar", "baz", "qux"]);
+
+	history.set_entries(["a".to_string(), "b".to_string(), "b".to_string()]);
+
+	assert_eq!(Some("b"), history.search_next(""));
+	assert_eq!(Some("a"), history.search_next(""));
+	assert_eq!(Some("a"), history.search_next(""));
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,7 @@
 //! - Ctrl-C: Send an `Interrupt` event
 
 use std::{
-	collections::VecDeque, fs::File, io::{self, stdout, BufRead, BufReader, BufWriter, Stdout, Write}, ops::DerefMut, path::Path, pin::Pin, task::{Context, Poll}
+	collections::VecDeque, io::{self, stdout, Stdout, Write}, ops::DerefMut, pin::Pin, task::{Context, Poll}
 };
 
 use crossterm::{
@@ -311,32 +311,6 @@ impl Readline {
 	/// Clears the current history.
 	pub fn clear_history(&mut self) {
 		self.set_history_entries([]);
-	}
-
-	/// Saves the history as a plain text file.
-	pub fn save_history(&self, path: impl AsRef<Path>) -> std::io::Result<()> {
-		let file = File::create(path)?;
-		let mut writer = BufWriter::new(file);
-
-		for line in self.get_history_entries() {
-			writeln!(writer, "{line}")?;
-		}
-
-		Ok(())
-	}
-
-	/// Loads the history from a plain text file.
-	pub fn load_history(&mut self, path: impl AsRef<Path>) -> std::io::Result<()> {
-		let file = File::open(path)?;
-		let reader = BufReader::new(file);
-
-		self.clear_history();
-
-		for line in reader.lines() {
-			self.add_history_entry(line?);
-		}
-
-		Ok(())
 	}
 }
 


### PR DESCRIPTION
This pull requests extends the history API slightly, to allow for the import and export of the history to a file. Detailed changes:

- Removed the `mpsc` channel for the history. This also gets rid of the `futures-channel` dependency of the crate itself.
- Added test code to the history (mainly to ensure that I didn't screw it up the refactor).
- Reversed the order of items in the history VecDeque, so that entries are ordered oldest-to-newest (more natural for the API).
- Slight change: when changing the history size, the history position is now reset. The old code left the position alone, so it could end up beyond the length of the history. Probably not critical, but I felt that resetting the history position seems reasonable here.
- Added functions in `Readline`:
  - `get_history_entries()` ... provides access to the internal VecDeque.
  - `set_history_entries()` ... allows for replacing the history contents.
  - `clear_history()`
  - `save_history()` ... saves the history to a plain text file
  - `load_history()` ... loads the history from a plain text file

Debatable API decisions:
- `set_history_entries()` will accept any `impl IntoIterator<Item = String>`. I didn't want to force users to use a `VecDeque`, but I could also change it.