### PR TITLE
Fix Divide by 0 error

### DIFF
--- a/src/line.rs
+++ b/src/line.rs
@@ -41,7 +41,7 @@ impl LineState {
 		Self {
 			prompt,
 			last_line_completed: true,
-			term_size,
+			term_size: (term_size.0.max(1), term_size.1),
 			current_column,
 			should_print_line_on_enter: true,
 			should_print_line_on_control_c: true,


### PR DESCRIPTION
Make it so term_size.0 can not be <= 0

tested with readline example:

docker compose up

![Screenshot 2025-04-03 200843](https://github.com/user-attachments/assets/a2e7ae66-383d-4853-9516-2fac6d6722e7)

docker attach

![Screenshot 2025-04-03 200858](https://github.com/user-attachments/assets/86d42724-f589-4760-b295-1e58fe7f559e)
