### PR TITLE
Fix for cursor positioning when prompt contains ANSI control sequences

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -518,18 +518,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ce301924b7887e9d637144fdade93f9dfff9b60981d4ac161db09720d39aa5"
 
 [[package]]
-name = "linux-raw-sys"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe7db12097d22ec582439daf8618b8fdd1a7bef6270e9af3b1ebcd30893cf413"
-
-[[package]]
-name = "litrs"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ce301924b7887e9d637144fdade93f9dfff9b60981d4ac161db09720d39aa5"
-
-[[package]]
 name = "lock_api"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/examples/test-ansi-stripping.rs
+++ b/examples/test-ansi-stripping.rs
@@ -1,0 +1,53 @@
+// This example tests the functionality of stripping ANSI escape codes
+// and reducing multi-byte characters to single character spaces in the
+// prompt line.
+//
+// Testing should be done by running the example and checking if the
+// prompt line is displayed correctly with color and that the cursor position
+// is correct when the program first runs, when a line is entered,
+// and when control-C is pressed.
+//
+// Note: This example requires unicode support in the terminal to render properly.
+
+use rustyline_async::{Readline, ReadlineEvent};
+use std::io::Write;
+use std::time::Duration;
+use tokio::time::sleep;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+	let (mut rl, mut stdout) = Readline::new("\x1b[1;31m🢡🢡🢡 \x1b[0m".into())?;
+
+	rl.should_print_line_on(false, false);
+
+	loop {
+		tokio::select! {
+			_ = sleep(Duration::from_secs(1)) => {
+				writeln!(stdout, "Message received!")?;
+			}
+			cmd = rl.readline() => match cmd {
+				Ok(ReadlineEvent::Line(line)) => {
+					writeln!(stdout, "You entered: {line:?}")?;
+					rl.add_history_entry(line.clone());
+					if line == "quit" {
+						break;
+					}
+				}
+				Ok(ReadlineEvent::Eof) => {
+					writeln!(stdout, "<EOF>")?;
+					break;
+				}
+				Ok(ReadlineEvent::Interrupted) => {
+					// writeln!(stdout, "^C")?;
+					continue;
+				}
+				Err(e) => {
+					writeln!(stdout, "Error: {e:?}")?;
+					break;
+				}
+			}
+		}
+	}
+	rl.flush()?;
+	Ok(())
+}

--- a/examples/test-ansi-stripping.rs
+++ b/examples/test-ansi-stripping.rs
@@ -1,13 +1,10 @@
 // This example tests the functionality of stripping ANSI escape codes
-// and reducing multi-byte characters to single character spaces in the
-// prompt line.
+// from the prompt length calculations.
 //
 // Testing should be done by running the example and checking if the
 // prompt line is displayed correctly with color and that the cursor position
 // is correct when the program first runs, when a line is entered,
 // and when control-C is pressed.
-//
-// Note: This example requires unicode support in the terminal to render properly.
 
 use rustyline_async::{Readline, ReadlineEvent};
 use std::io::Write;
@@ -16,7 +13,7 @@ use tokio::time::sleep;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-	let (mut rl, mut stdout) = Readline::new("\x1b[1;31m🢡🢡🢡 \x1b[0m".into())?;
+	let (mut rl, mut stdout) = Readline::new("\x1b[1;31m>>> \x1b[0m".into())?;
 
 	rl.should_print_line_on(false, false);
 

--- a/src/line.rs
+++ b/src/line.rs
@@ -21,7 +21,7 @@ fn get_sanitized_size(message: &str) -> u16 {
 			if let Some(next) = prompt_stream.next() {
 				if next == "[" {
 					while let Some(c) = prompt_stream.next() {
-						if c == "m" {
+						if c.is_ascii() && (0x40..=0x7E).contains(&c.as_bytes()[0]) {
 							break;
 						}
 					}


### PR DESCRIPTION
resolves #39 

Attempting to color the prompt using ANSI control sequences such as `\x1b[31m` will cause the cursor to be offset by the number of bytes in the control sequence.

This PR is my own attempt to fix the issue, and it guarantees any control sequences beginning with `ESC [` in the prompt will be ignored for cursor position calculations.