### PR TITLE
fix updated prompt length

### DIFF
--- a/src/line.rs
+++ b/src/line.rs
@@ -181,6 +181,7 @@ impl LineState {
 		self.clear(term)?;
 		self.prompt.clear();
 		self.prompt.push_str(prompt);
+		self.prompt_len = ansi_width(&self.prompt) as u16;
 		// recalculates column
 		self.move_cursor(0)?;
 		self.render(term)?;


### PR DESCRIPTION
bug repro: update the promt to a different size and the cursor will be at the wrong place