### PR TITLE
fix: use absolute cursor positioning to prevent drift with async output

### DIFF
--- a/src/line.rs
+++ b/src/line.rs
@@ -70,7 +70,8 @@ impl LineState {
 		if line_height != 0 {
 			term.queue(cursor::MoveDown(line_height))?;
 		}
-		term.queue(cursor::MoveRight(line_remaining_len))?;
+		// Use absolute positioning to prevent cursor drift with async output
+		term.queue(cursor::MoveToColumn(line_remaining_len))?;
 
 		Ok(())
 	}


### PR DESCRIPTION
This fixes a bug I noticed when using rustyline-async. When async output is written to the terminal, the cursor position can diverge from what rustyline-async expects. Using relative MoveRight moves from the wrong position, causing cursor offset bugs. Absolute MoveToColumn always positions correctly regardless of terminal state.